### PR TITLE
Feature/speed up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - [unreleased]
 ### Added:
 - Webservice: Added endpoint to get building metadata for a given building type at `/v1/metadata/building/{type}`.
+- Configuration: Added the config option `speedUpEverything`. When set to `true`, every building / research / ship takes 1 round to complete, needs no resources and all prerequisites are disabled.
 
 ### Fixed:
 - Webservice: Fixed a bug where the building metadata and technology metadata endpoint responded with 500 Server Error when passing a level smaller than 1.

--- a/rest/config.yaml
+++ b/rest/config.yaml
@@ -19,6 +19,9 @@ planets: 3
 # Round time in seconds
 roundTime: 10
 
+# If true, everything will be finished in one round
+speedUpEverything: false
+
 # Database configuration
 database:
     driverClass: org.h2.Driver

--- a/rest/config.yaml
+++ b/rest/config.yaml
@@ -19,7 +19,7 @@ planets: 3
 # Round time in seconds
 roundTime: 10
 
-# If true, everything will be finished in one round
+# If true, everything will be finished in one round, prerequisites are disabled and every build / research costs zero resources
 speedUpEverything: false
 
 # Database configuration

--- a/rest/src/main/java/restwars/rest/RestwarsApplication.java
+++ b/rest/src/main/java/restwars/rest/RestwarsApplication.java
@@ -75,7 +75,8 @@ public class RestwarsApplication extends Application<RestwarsConfiguration> {
 
         UniverseConfiguration universeConfiguration = new UniverseConfiguration(
                 configuration.getGalaxies(), configuration.getSolarSystems(), configuration.getPlanets(),
-                new Resources(1000L, 200L, 200L), configuration.getRoundTime()
+                new Resources(1000L, 200L, 200L), configuration.getRoundTime(),
+                configuration.isSpeedUpEverything()
         );
 
         ObjectGraph objectGraph = ObjectGraph.create(new RestWarsModule(universeConfiguration, dataSource, configuration.getPasswordIterations()));

--- a/rest/src/main/java/restwars/rest/configuration/RestwarsConfiguration.java
+++ b/rest/src/main/java/restwars/rest/configuration/RestwarsConfiguration.java
@@ -64,6 +64,11 @@ public class RestwarsConfiguration extends Configuration {
     @Min(1)
     private int roundTime;
 
+    /**
+     * If true, everything will be finished in one round.
+     */
+    private boolean speedUpEverything = false;
+
     public DataSourceFactory getDatabase() {
         return database;
     }
@@ -130,5 +135,13 @@ public class RestwarsConfiguration extends Configuration {
 
     public void setPasswordCache(String passwordCache) {
         this.passwordCache = passwordCache;
+    }
+
+    public boolean isSpeedUpEverything() {
+        return speedUpEverything;
+    }
+
+    public void setSpeedUpEverything(boolean speedUpEverything) {
+        this.speedUpEverything = speedUpEverything;
     }
 }

--- a/service/src/main/java/restwars/model/UniverseConfiguration.java
+++ b/service/src/main/java/restwars/model/UniverseConfiguration.java
@@ -9,8 +9,9 @@ public class UniverseConfiguration {
     private final int planetsPerSolarSystem;
     private final Resources startingResources;
     private final int roundTimeInSeconds;
+    private final boolean speedUpEverything;
 
-    public UniverseConfiguration(int galaxyCount, int solarSystemsPerGalaxy, int planetsPerSolarSystem, Resources startingResources, int roundTimeInSeconds) {
+    public UniverseConfiguration(int galaxyCount, int solarSystemsPerGalaxy, int planetsPerSolarSystem, Resources startingResources, int roundTimeInSeconds, boolean speedUpEverything) {
         Preconditions.checkNotNull(startingResources, "startingResources");
         Preconditions.checkArgument(startingResources.getCrystals() >= 0, "Starting crystals must be >= 0");
         Preconditions.checkArgument(startingResources.getGas() >= 0, "Starting gas must be >= 0");
@@ -25,6 +26,7 @@ public class UniverseConfiguration {
         this.planetsPerSolarSystem = planetsPerSolarSystem;
         this.roundTimeInSeconds = roundTimeInSeconds;
         this.startingResources = startingResources;
+        this.speedUpEverything = speedUpEverything;
     }
 
     public int getGalaxyCount() {
@@ -45,5 +47,9 @@ public class UniverseConfiguration {
 
     public int getRoundTimeInSeconds() {
         return roundTimeInSeconds;
+    }
+
+    public boolean isSpeedUpEverything() {
+        return speedUpEverything;
     }
 }

--- a/service/src/main/java/restwars/service/di/MechanicsModule.java
+++ b/service/src/main/java/restwars/service/di/MechanicsModule.java
@@ -2,14 +2,12 @@ package restwars.service.di;
 
 import dagger.Module;
 import dagger.Provides;
+import restwars.model.UniverseConfiguration;
 import restwars.service.mechanics.BuildingMechanics;
 import restwars.service.mechanics.PlanetMechanics;
 import restwars.service.mechanics.ShipMechanics;
 import restwars.service.mechanics.TechnologyMechanics;
-import restwars.service.mechanics.impl.BuildingMechanicsImpl;
-import restwars.service.mechanics.impl.PlanetMechanicsImpl;
-import restwars.service.mechanics.impl.ShipMechanicsImpl;
-import restwars.service.mechanics.impl.TechnologyMechanicsImpl;
+import restwars.service.mechanics.impl.*;
 
 /**
  * Dagger module which provides the mechanics.
@@ -22,17 +20,35 @@ public class MechanicsModule {
     }
 
     @Provides
-    BuildingMechanics provideBuildingMechanics() {
-        return new BuildingMechanicsImpl();
+    BuildingMechanics provideBuildingMechanics(UniverseConfiguration universeConfiguration) {
+        BuildingMechanicsImpl mechanics = new BuildingMechanicsImpl();
+
+        if (universeConfiguration.isSpeedUpEverything()) {
+            return new SpeedUpBuildingMechanicsImpl(mechanics);
+        }
+
+        return mechanics;
     }
 
     @Provides
-    ShipMechanics provideShipMechanics() {
-        return new ShipMechanicsImpl();
+    ShipMechanics provideShipMechanics(UniverseConfiguration universeConfiguration) {
+        ShipMechanicsImpl mechanics = new ShipMechanicsImpl();
+
+        if (universeConfiguration.isSpeedUpEverything()) {
+            return new SpeedUpShipMechanics(mechanics);
+        }
+
+        return mechanics;
     }
 
     @Provides
-    TechnologyMechanics providesTechnologyMechanics() {
-        return new TechnologyMechanicsImpl();
+    TechnologyMechanics providesTechnologyMechanics(UniverseConfiguration universeConfiguration) {
+        TechnologyMechanicsImpl mechanics = new TechnologyMechanicsImpl();
+
+        if (universeConfiguration.isSpeedUpEverything()) {
+            return new SpeedUpTechnologyMechanicsImpl(mechanics);
+        }
+
+        return mechanics;
     }
 }

--- a/service/src/main/java/restwars/service/mechanics/impl/SpeedUpBuildingMechanicsImpl.java
+++ b/service/src/main/java/restwars/service/mechanics/impl/SpeedUpBuildingMechanicsImpl.java
@@ -1,0 +1,80 @@
+package restwars.service.mechanics.impl;
+
+import com.google.common.base.Preconditions;
+import restwars.model.building.BuildingType;
+import restwars.model.resource.Resources;
+import restwars.model.techtree.Prerequisites;
+import restwars.service.mechanics.BuildingMechanics;
+
+public class SpeedUpBuildingMechanicsImpl implements BuildingMechanics {
+    private final BuildingMechanics delegate;
+
+    public SpeedUpBuildingMechanicsImpl(BuildingMechanics delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    }
+
+    @Override
+    public Resources calculateBuildCost(BuildingType type, int level) {
+        return Resources.NONE;
+    }
+
+    @Override
+    public Resources calculateCommandCenterResourcesGathered(int level) {
+        return delegate.calculateCommandCenterResourcesGathered(level);
+    }
+
+    @Override
+    public int calculateBuildTime(BuildingType type, int level) {
+        return 1;
+    }
+
+    @Override
+    public int calculateCrystalsGathered(int level) {
+        return delegate.calculateCrystalsGathered(level);
+    }
+
+    @Override
+    public int calculateGasGathered(int level) {
+        return delegate.calculateGasGathered(level);
+    }
+
+    @Override
+    public int calculateEnergyGathered(int level) {
+        return delegate.calculateEnergyGathered(level);
+    }
+
+    @Override
+    public double calculateBuildingBuildTimeSpeedup(int level) {
+        return delegate.calculateBuildingBuildTimeSpeedup(level);
+    }
+
+    @Override
+    public double calculateResearchTimeSpeedup(int level) {
+        return delegate.calculateResearchTimeSpeedup(level);
+    }
+
+    @Override
+    public double calculateShipBuildTimeSpeedup(int level) {
+        return delegate.calculateShipBuildTimeSpeedup(level);
+    }
+
+    @Override
+    public int calculateScanRange(int level) {
+        return delegate.calculateScanRange(level);
+    }
+
+    @Override
+    public int calculateFlightDetectionRange(int level) {
+        return delegate.calculateFlightDetectionRange(level);
+    }
+
+    @Override
+    public double calculateFleetSizeVariance(int level) {
+        return delegate.calculateFleetSizeVariance(level);
+    }
+
+    @Override
+    public Prerequisites getPrerequisites(BuildingType type) {
+        return Prerequisites.NONE;
+    }
+}

--- a/service/src/main/java/restwars/service/mechanics/impl/SpeedUpShipMechanics.java
+++ b/service/src/main/java/restwars/service/mechanics/impl/SpeedUpShipMechanics.java
@@ -1,0 +1,55 @@
+package restwars.service.mechanics.impl;
+
+import com.google.common.base.Preconditions;
+import restwars.model.resource.Resources;
+import restwars.model.ship.ShipType;
+import restwars.model.techtree.Prerequisites;
+import restwars.service.mechanics.ShipMechanics;
+
+public class SpeedUpShipMechanics implements ShipMechanics {
+    private final ShipMechanics delegate;
+
+    public SpeedUpShipMechanics(ShipMechanics delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    }
+
+    @Override
+    public Resources getBuildCost(ShipType type) {
+        return Resources.NONE;
+    }
+
+    @Override
+    public int getBuildTime(ShipType type) {
+        return 1;
+    }
+
+    @Override
+    public double getFlightCostModifier(ShipType type) {
+        return 0;
+    }
+
+    @Override
+    public double getFlightSpeed(ShipType type) {
+        return Double.MAX_VALUE;
+    }
+
+    @Override
+    public int getAttackPoints(ShipType type) {
+        return delegate.getAttackPoints(type);
+    }
+
+    @Override
+    public int getDefensePoints(ShipType type) {
+        return delegate.getDefensePoints(type);
+    }
+
+    @Override
+    public int getCargoSpace(ShipType type) {
+        return delegate.getCargoSpace(type);
+    }
+
+    @Override
+    public Prerequisites getPrerequisites(ShipType type) {
+        return Prerequisites.NONE;
+    }
+}

--- a/service/src/main/java/restwars/service/mechanics/impl/SpeedUpTechnologyMechanicsImpl.java
+++ b/service/src/main/java/restwars/service/mechanics/impl/SpeedUpTechnologyMechanicsImpl.java
@@ -1,0 +1,40 @@
+package restwars.service.mechanics.impl;
+
+import com.google.common.base.Preconditions;
+import restwars.model.resource.Resources;
+import restwars.model.technology.TechnologyType;
+import restwars.model.techtree.Prerequisites;
+import restwars.service.mechanics.TechnologyMechanics;
+
+public class SpeedUpTechnologyMechanicsImpl implements TechnologyMechanics {
+    private final TechnologyMechanics delegate;
+
+    public SpeedUpTechnologyMechanicsImpl(TechnologyMechanics delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    }
+
+    @Override
+    public Resources calculateResearchCost(TechnologyType type, int level) {
+        return Resources.NONE;
+    }
+
+    @Override
+    public int calculateResearchTime(TechnologyType type, int level) {
+        return 1;
+    }
+
+    @Override
+    public Prerequisites getPrerequisites(TechnologyType type) {
+        return Prerequisites.NONE;
+    }
+
+    @Override
+    public double calculateBuildCostReduction(int level) {
+        return delegate.calculateBuildCostReduction(level);
+    }
+
+    @Override
+    public double calculateCombustionFlightCostReduction(int level) {
+        return delegate.calculateCombustionFlightCostReduction(level);
+    }
+}


### PR DESCRIPTION
Configuration: Added the config option `speedUpEverything`. When set to `true`, every building / research / ship takes 1 round to complete, needs no resources and all prerequisites are disabled.